### PR TITLE
fixing docker build to be able to compile typescript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
+FROM node:19-slim as build
+WORKDIR /usr/src/app
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm install
+COPY src/ src/
+RUN npm run build
+
+
 FROM node:19-slim
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm ci --production
 RUN npm cache clean --force
 ENV NODE_ENV="production"
-COPY . .
+COPY --from=build /usr/src/app/lib/ lib/
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Docker build was not working since the line 
`COPY . . `

relied on the lib folder to be present after a npm run build, but since only prod dependencies were installed the typescript compiler was not available.

I have pulled out the build step into a separate build step to install all dependencies, then compile the .ts files and then copy the result over to the main image. 